### PR TITLE
refactor: support for @hapi/joi 16.1.1

### DIFF
--- a/express-joi-validation.d.ts
+++ b/express-joi-validation.d.ts
@@ -75,7 +75,6 @@ export interface ValidatedRequestWithRawInputsAndFields<
  * Configuration options supported by *createValidator(config)*
  */
 export interface ExpressJoiConfig {
-  joi?: typeof Joi
   statusCode?: number
   passError?: boolean
 }

--- a/express-joi-validation.js
+++ b/express-joi-validation.js
@@ -67,9 +67,6 @@ module.exports = function() {
 
 module.exports.createValidator = function generateJoiMiddlewareInstance(cfg) {
   cfg = cfg || {} // default to an empty config
-
-  const Joi = cfg.joi || require('@hapi/joi')
-
   // We'll return this instance of the middleware
   const instance = {
     response
@@ -83,7 +80,7 @@ module.exports.createValidator = function generateJoiMiddlewareInstance(cfg) {
       opts = opts || {} // like config, default to empty object
 
       return function exporessJoiValidator(req, res, next) {
-        const ret = Joi.validate(req[type], schema, opts.joi || container.joi)
+        const ret = schema.validate(req[type], opts.joi || container.joi)
 
         if (!ret.error) {
           req[container.storageProperty] = req[type]
@@ -111,7 +108,7 @@ module.exports.createValidator = function generateJoiMiddlewareInstance(cfg) {
       next()
 
       function validateJson(json) {
-        const ret = Joi.validate(json, schema, opts.joi)
+        const ret = schema.validate(json, opts.joi)
         const { error, value } = ret
         if (!error) {
           // return res.json ret to retain express compatibility

--- a/index.test.js
+++ b/index.test.js
@@ -269,47 +269,5 @@ describe('express joi', function() {
         done()
       })
     })
-
-    it('should use supplied config.joi and config.statusCode', function(done) {
-      const errStr = '"id" is required'
-      const statusCode = 403
-
-      const joiStub = {
-        validate: sinon.stub().returns({
-          error: {
-            details: [
-              {
-                message: errStr
-              }
-            ]
-          }
-        })
-      }
-
-      const reqStub = {
-        query: {}
-      }
-
-      const resStub = {
-        end: str => {
-          expect(joiStub.validate.called).to.be.true
-          expect(resStub.status.calledWith(statusCode)).to.be.true
-          expect(str).to.equal(`Error validating request query. ${errStr}.`)
-          done()
-        }
-      }
-      resStub.status = sinon.stub().returns(resStub)
-
-      const mod = require('./express-joi-validation.js').createValidator({
-        joi: joiStub,
-        statusCode: statusCode
-      })
-
-      const mw = mod.query(Joi.object({}))
-
-      mw(reqStub, resStub, () => {
-        done(new Error('next should not be called'))
-      })
-    })
   })
 })


### PR DESCRIPTION
@hapi/joi 16.1.1 doesn't have a root validate method `Joi.validate()`. Instead call validate on the schema. 

All tagged versions of @hapi/Joi have a validate method on the schema object so should be backwards compatible.