### PR TITLE
Fixed bug in Response validator

### DIFF
--- a/express-joi-validation.js
+++ b/express-joi-validation.js
@@ -108,6 +108,8 @@ module.exports.createValidator = function generateJoiMiddlewareInstance(cfg) {
           // return res.json ret to retain express compatibility
           return resJson(value)
         } else if (opts.passError || cfg.passError) {
+          // return res.json to allow error handler to modify the json
+          res.json = resJson
           ret.type = type
           next(ret)
         } else {

--- a/express-joi-validation.js
+++ b/express-joi-validation.js
@@ -59,6 +59,19 @@ function buildErrorString(err, container) {
   return ret
 }
 
+function patchResponseForResponseValidation(res, validationFn) {
+  res._origJson = res.json.bind(res)
+  res.json = validationFn
+}
+
+function restoreResponseAfterResponseValidation(res) {
+  if (res._origJson) {
+    res.json = res._origJson
+  }
+}
+
+module.exports.fixupResponse = restoreResponseAfterResponseValidation
+
 module.exports.createValidator = function generateJoiMiddlewareInstance(cfg) {
   cfg = cfg || {} // default to an empty config
   // We'll return this instance of the middleware
@@ -97,8 +110,7 @@ module.exports.createValidator = function generateJoiMiddlewareInstance(cfg) {
   function response(schema, opts = {}) {
     const type = 'response'
     return (req, res, next) => {
-      const resJson = res.json.bind(res)
-      res.json = validateJson
+      patchResponseForResponseValidation(res, validateJson)
       next()
 
       function validateJson(json) {
@@ -106,10 +118,9 @@ module.exports.createValidator = function generateJoiMiddlewareInstance(cfg) {
         const { error, value } = ret
         if (!error) {
           // return res.json ret to retain express compatibility
-          return resJson(value)
+          return res._origJson(value)
         } else if (opts.passError || cfg.passError) {
-          // return res.json to allow error handler to modify the json
-          res.json = resJson
+          restoreResponseAfterResponseValidation(res)
           ret.type = type
           next(ret)
         } else {


### PR DESCRIPTION
Response validator replaces res.json with a custom function.
In case the user configured passError option, we need to restore the
original res.json function so that the error handling middleware can
update the response.