### PR TITLE
Narrow down ExpressJoiError type to assume the Joi.ValidationResult is an error

### DIFF
--- a/express-joi-validation.d.ts
+++ b/express-joi-validation.d.ts
@@ -25,8 +25,8 @@ export enum ContainerTypes {
  * Use this in you express error handler if you've set *passError* to true
  * when calling *createValidator*
  */
-export type ExpressJoiError = Extract<
-  Joi.ValidationResult,
+export type ExpressJoiError<TSchema = any> = Extract<
+  Joi.ValidationResult<TSchema>,
   { error: Joi.ValidationError }
 > & {
   type: ContainerTypes;

--- a/express-joi-validation.d.ts
+++ b/express-joi-validation.d.ts
@@ -25,9 +25,12 @@ export enum ContainerTypes {
  * Use this in you express error handler if you've set *passError* to true
  * when calling *createValidator*
  */
-export type ExpressJoiError = Joi.ValidationResult & {
-  type: ContainerTypes
-}
+export type ExpressJoiError = Extract<
+  Joi.ValidationResult,
+  { error: Joi.ValidationError }
+> & {
+  type: ContainerTypes;
+};
 
 /**
  * A schema that developers should extend to strongly type the properties

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "express-joi-validation",
-  "version": "5.0.1",
+  "version": "5.0.2",
   "description": "validate express application inputs and parameters using joi",
   "main": "express-joi-validation.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "express-joi-validation",
-  "version": "5.0.2",
+  "version": "5.1.0",
   "description": "validate express application inputs and parameters using joi",
   "main": "express-joi-validation.js",
   "scripts": {


### PR DESCRIPTION
👋 

While writing some error handling middleware using ExpressJoiError I noticed that the type also includes the non-error type of the `Joi.ValidationResult`:
```ts
{
    error: undefined;
    warning?: ValidationError;
    value: TSchema;
}
```

I assume (and correct me if I'm wrong!) that the ExpressJoiError is only raised when the `Joi.ValidationResult` contains the error field. If that is true then `Extract`ing the error variant of the type will result in a more narrow type to use. 

Additionally I've also added the `TSchema` generic type on the ExpressJoiError that's passed into the `Joi.ValidationResult` to allow for more accurate handling when it comes to the schema that raised the error.